### PR TITLE
SFC 51 fe load the conversation in the chat after clicking on an item from the conversation history

### DIFF
--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -10,6 +10,11 @@ export type ConversationHistoryItem = {
     content: string,
 };
 
+export type ConversationChatItem = {
+    role: string,
+    content: string
+}
+
 export type AskRequestOverrides = {
     semanticRanker?: boolean;
     semanticCaptions?: boolean;

--- a/frontend/src/components/ChatHistoryButton/ChatHistoryButton.module.css
+++ b/frontend/src/components/ChatHistoryButton/ChatHistoryButton.module.css
@@ -9,6 +9,8 @@
     padding: 4px 12px;
     transition: .2s;
     background-color: white;
+    width: 178px;
+    margin-right: 5px;
 }
 
 .container:hover{

--- a/frontend/src/components/HistoryPannel/ChatHistoryListItem.tsx
+++ b/frontend/src/components/HistoryPannel/ChatHistoryListItem.tsx
@@ -30,10 +30,9 @@ export const ChatHistoryPanelList = () => {
             const data = await getChatHistory(userId);
             if(data.length > 0){
               const sortedData = data.sort((a, b) => {
-                // Convertir las fechas a objetos Date para compararlas
                 const dateA = new Date(a.start_date);
                 const dateB = new Date(b.start_date);
-                return dateB.getTime() - dateA.getTime(); // Orden descendente
+                return dateB.getTime() - dateA.getTime();
             });
               setDataHistory(sortedData)
               setIsLoading(false);

--- a/frontend/src/components/HistoryPannel/ChatHistoryListItem.tsx
+++ b/frontend/src/components/HistoryPannel/ChatHistoryListItem.tsx
@@ -1,16 +1,19 @@
 import styles from "./ChatHistoryPannel.module.css";
-import { getChatHistory } from "../../api";
+import { getChatHistory, getChatFromHistoryPannelById } from "../../api";
 import { useEffect, useState } from "react";
 import { useAppContext } from "../../providers/AppProviders";
 import trash from "../../assets/trash.png"
 import pencil from "../../assets/pencil.png"
+import { Spinner } from "@fluentui/react";
 
 export const ChatHistoryPanelList = () => {
 
   const [hoveredItemIndex, setHoveredItemIndex] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const {dataHistory, setDataHistory, userId} = useAppContext()
+  const [chatSelected, setChatSelected] = useState("");
+  const [conversationsIds, setConversationsIds] = useState<String[]>([]);
+  const {dataHistory, setDataHistory, userId, dataConversation, setDataConversation, setConversationIsLoading, setChatId, chatId, refreshFetchHistorial, setRefreshFetchHistorial } = useAppContext()
 
 
   const handleMouseEnter = (index: string) => {
@@ -26,8 +29,18 @@ export const ChatHistoryPanelList = () => {
         try {
             const data = await getChatHistory(userId);
             if(data.length > 0){
-              setDataHistory(data)
+              const sortedData = data.sort((a, b) => {
+                // Convertir las fechas a objetos Date para compararlas
+                const dateA = new Date(a.start_date);
+                const dateB = new Date(b.start_date);
+                return dateB.getTime() - dateA.getTime(); // Orden descendente
+            });
+              setDataHistory(sortedData)
               setIsLoading(false);
+              const ids = sortedData.map(data => (data.id))
+              if(!ids.every(id => conversationsIds.includes(id))){
+                setConversationsIds(ids)
+              }
             }else{
               setIsLoading(false);
               setErrorMessage("There are not conversation history yet.")
@@ -39,9 +52,47 @@ export const ChatHistoryPanelList = () => {
         }
     };
 
-  useEffect(() => {
-    fetchData();
-  }, [userId]);
+  const fetchConversation = async (chatConversationId: string) => {
+        try {
+          if(!chatSelected.includes(chatConversationId)){
+            setChatSelected(chatConversationId)
+            setChatId(chatConversationId);
+            setConversationIsLoading(true)
+            const data = await getChatFromHistoryPannelById(chatConversationId, userId);
+            if(data.length > 0){
+              setDataConversation(data)
+              setConversationIsLoading(false)
+            }
+          }
+        } catch (error) {
+            console.error('Error fetching data:', error);
+            setConversationIsLoading(false)
+            setErrorMessage(`Was an error fetching data: ${error}`)
+        }
+    };
+
+    const handleRefreshHistoial = async () => {
+      if(refreshFetchHistorial){
+        await fetchData()
+        setRefreshFetchHistorial(false)
+      }else{
+        return
+      }
+    }
+  
+    useEffect(() => {
+
+      if(dataHistory.length <= 0 || !conversationsIds.every(id => dataHistory.some(item => item.id === id))){
+        fetchData();
+      }else{
+        setIsLoading(false)
+      }
+
+      if(refreshFetchHistorial){
+      handleRefreshHistoial();
+      }
+
+    }, [userId, dataHistory, conversationsIds, refreshFetchHistorial]);
 
   const months = [
     "January", "February", "March", "April",
@@ -67,7 +118,7 @@ export const ChatHistoryPanelList = () => {
       <div className={styles.listContainer}>
         {isLoading && (
           <div className={styles.loaderContainer}>
-            <div className={styles.customLoader}></div>
+            <Spinner size={3} />
           </div>
         )}
         {errorMessage !== null ? (
@@ -82,19 +133,20 @@ export const ChatHistoryPanelList = () => {
                     {data.map((conversation, index) => (
                       <div
                         key={conversation.id}
-                        className={styles.conversationContainer}
+                        className={chatSelected === conversation.id || chatId === conversation.id ? styles.conversationSelected : styles.conversationContainer}
                         onMouseEnter={() => handleMouseEnter(`${monthIndex}-${index}`)}
                         onMouseLeave={handleMouseLeave}
+                        onClick={() => fetchConversation(conversation.id)}
                       >
                         <button className={styles.buttonConversation}>
                           {conversation.content}
                         </button>
-                        {hoveredItemIndex === `${monthIndex}-${index}` && (
+                        {hoveredItemIndex === `${monthIndex}-${index}` || chatSelected === conversation.id || chatId === conversation.id ? (
                           <div className={styles.actionsButtons}>
                             <img className={styles.actionButton} src={trash} alt="Destroy" />
                             <img className={styles.actionButton} src={pencil} alt="Edit" />
                           </div>
-                        )}
+                        ):(<></>)}
                       </div>
                     ))}
                   </>

--- a/frontend/src/components/HistoryPannel/ChatHistoryPannel.module.css
+++ b/frontend/src/components/HistoryPannel/ChatHistoryPannel.module.css
@@ -75,6 +75,15 @@
 .conversationContainer{
     display: flex;
     border-radius: 5px;
+    margin-bottom: 4px;
+}
+
+.conversationSelected{
+    background-color: rgba(221, 221, 221, 0.349);
+    display: flex;
+    border-radius: 5px;
+    margin-bottom: 4px;
+    transition: .2s;
 }
 
 .conversationContainer:hover{

--- a/frontend/src/components/SettingsModal/SettingsModal.module.css
+++ b/frontend/src/components/SettingsModal/SettingsModal.module.css
@@ -1,9 +1,25 @@
 .button {
-    color: rgb(63, 63, 63);
-    font-size: 24px;
-    border: none; 
-    width: 100%;
     display: flex;
+    align-items: center;
+    margin-top: 5px;
+    gap: 6px;
+    cursor: pointer;
+    border: 1.5px solid rgb(231, 231, 231);
+    border-radius: 5px;
+    padding: 4px 12px;
+    transition: .2s;
+    background-color: white;
+    font-size: 24px;
+    width: 100%;
+    height: 35px;
+}
+
+.button:hover {
+    background-color: rgb(243, 243, 243);
+}
+
+.button:active {
+    background-color: white;
 }
 
 .buttonText {

--- a/frontend/src/pages/chat/Chat.module.css
+++ b/frontend/src/pages/chat/Chat.module.css
@@ -62,6 +62,10 @@
     }
 }
 
+.conversationIsLoading{
+    display: "none";
+}
+
 .chatMessageStream {
     flex-grow: 1;
     max-height: 1024px;
@@ -128,6 +132,10 @@
     align-self: flex-start;
     height: 95%;
     overflow-y: hidden;
+}
+
+.spinnerStyles{
+    position: absolute;
 }
 
 .commandsContainer::-webkit-scrollbar {

--- a/frontend/src/pages/chat/Chat.module.css
+++ b/frontend/src/pages/chat/Chat.module.css
@@ -62,8 +62,25 @@
     }
 }
 
+.noneDisplay{
+    display: none;
+}
+
+.flexDescription{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
 .conversationIsLoading{
-    display: "none";
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    max-height: 1024px;
+    padding-top: 60px;
 }
 
 .chatMessageStream {

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -18,7 +18,6 @@ import salesLogo from "../../img/logo.png";
 import { useAppContext } from "../../providers/AppProviders";
 import { ChatHistoryPanel } from "../../components/HistoryPannel/ChatHistoryPanel";
 
-
 const userLanguage = navigator.language;
 let error_message_text = "";
 if (userLanguage.startsWith("pt")) {
@@ -44,8 +43,7 @@ const Chat = () => {
 
     const chatContainerRef = useRef<HTMLDivElement>(null);
 
-    const {showHistoryPanel, dataConversation, setDataConversation, chatId, conversationIsLoading, setRefreshFetchHistorial, setChatId} = useAppContext()
-
+    const { showHistoryPanel, dataConversation, setDataConversation, chatId, conversationIsLoading, setRefreshFetchHistorial, setChatId } = useAppContext();
 
     const lastQuestionRef = useRef<string>("");
     const chatMessageStreamEnd = useRef<HTMLDivElement | null>(null);
@@ -63,68 +61,6 @@ const Chat = () => {
     const [userId, setUserId] = useState<string>("");
     const triggered = useRef(false);
 
-    // const continueConversation = async (chatId: string, question: string) => {
-    //     lastQuestionRef.current = question;
-
-    //     error && setError(undefined);
-    //     setIsLoading(true);
-    //     setActiveCitation(undefined);
-    //     setActiveAnalysisPanelTab(undefined);
-
-    //     try {
-    //         const history: ChatTurn[] = answers.map(a => ({ user: a[0], bot: a[1].answer }));
-    //         const request: ChatRequestGpt = {
-    //             history: [...history, { user: question, bot: undefined }],
-    //             approach: Approaches.ReadRetrieveRead,
-    //             conversation_id: chatId,
-    //             query: question,
-    //             overrides: {
-    //                 promptTemplate: promptTemplate.length === 0 ? undefined : promptTemplate,
-    //                 excludeCategory: excludeCategory.length === 0 ? undefined : excludeCategory,
-    //                 top: retrieveCount,
-    //                 semanticRanker: useSemanticRanker,
-    //                 semanticCaptions: useSemanticCaptions,
-    //                 suggestFollowupQuestions: useSuggestFollowupQuestions
-    //             }
-    //         };
-    //         const result = await chatApiGpt(request);
-    //         console.log(result);
-    //         console.log(result.answer);
-    //         setAnswers([...answers, [question, result]]);
-    //         setUserId(result.conversation_id);
-
-    //         // Voice Synthesis
-    //         if (speechSynthesisEnabled) {
-    //             const tokenObj = await getTokenOrRefresh();
-    //             const speechConfig = SpeechConfig.fromAuthorizationToken(tokenObj.authToken, tokenObj.region);
-    //             const audioConfig = AudioConfig.fromDefaultSpeakerOutput();
-    //             speechConfig.speechSynthesisLanguage = tokenObj.speechSynthesisLanguage;
-    //             speechConfig.speechSynthesisVoiceName = tokenObj.speechSynthesisVoiceName;
-    //             const synthesizer = new SpeechSynthesizer(speechConfig, audioConfig);
-
-    //             synthesizer.speakTextAsync(
-    //                 result.answer.replace(/ *\[[^)]*\] */g, ""),
-    //                 function (result) {
-    //                     if (result.reason === ResultReason.SynthesizingAudioCompleted) {
-    //                         console.log("synthesis finished.");
-    //                     } else {
-    //                         console.error("Speech synthesis canceled, " + result.errorDetails + "\nDid you update the subscription info?");
-    //                     }
-    //                     synthesizer.close();
-    //                 },
-    //                 function (err) {
-    //                     console.trace("err - " + err);
-    //                     synthesizer.close();
-    //                 }
-    //             );
-    //         }
-    //     } catch (e) {
-    //         setError(e);
-    //     } finally {
-    //         setIsLoading(false);
-    //     }
-    // }
-
     const makeApiRequestGpt = async (question: string, chatId: string | null) => {
         lastQuestionRef.current = question;
 
@@ -134,10 +70,10 @@ const Chat = () => {
         setActiveAnalysisPanelTab(undefined);
 
         try {
-            let history: ChatTurn[] = [];;
-            if(dataConversation.length > 0){
+            let history: ChatTurn[] = [];
+            if (dataConversation.length > 0) {
                 history.push(...dataConversation);
-            }else{
+            } else {
                 history.push(...answers.map(a => ({ user: a[0], bot: a[1].answer })));
             }
             history.push({ user: question, bot: undefined });
@@ -156,22 +92,22 @@ const Chat = () => {
                 }
             };
             const result = await chatApiGpt(request);
-            const conditionOne = answers.map(a => ({ user: a[0]}))
-            if(conditionOne.length <= 0){
+            const conditionOne = answers.map(a => ({ user: a[0] }));
+            if (conditionOne.length <= 0) {
                 setRefreshFetchHistorial(true);
-                setChatId(result.conversation_id)
-            }else{
+                setChatId(result.conversation_id);
+            } else {
                 setRefreshFetchHistorial(false);
             }
             setAnswers([...answers, [question, result]]);
             setUserId(result.conversation_id);
             const response = {
-                                answer: result.answer || "",
-                                conversation_id: chatId,
-                                data_points: [""],
-                                thoughts: null
-                            } as AskResponse
-            setDataConversation([...dataConversation, {user: question, bot: response.answer}])
+                answer: result.answer || "",
+                conversation_id: chatId,
+                data_points: [""],
+                thoughts: null
+            } as AskResponse;
+            setDataConversation([...dataConversation, { user: question, bot: response.answer }]);
 
             // Voice Synthesis
             if (speechSynthesisEnabled) {
@@ -246,7 +182,7 @@ const Chat = () => {
     useEffect(() => {
         chatMessageStreamEnd.current?.scrollIntoView({ behavior: "smooth" });
         if (dataConversation.length > 0) {
-            chatContainerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+            chatContainerRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
         }
         if (triggered.current === false) {
             triggered.current = true;
@@ -339,80 +275,72 @@ const Chat = () => {
     return (
         <div className={styles.mainContainer}>
             <div>
-                <div className={styles.commandsContainer}>
-                    {showHistoryPanel && (
-                        <ChatHistoryPanel />
-                    )}
-                </div>
+                <div className={styles.commandsContainer}>{showHistoryPanel && <ChatHistoryPanel />}</div>
             </div>
             <div className={styles.container}>
-                <div className={styles.chatRoot} style={ showHistoryPanel ? { alignSelf: "flex-start" } : {}}>
+                <div className={styles.chatRoot} style={showHistoryPanel ? { alignSelf: "flex-start" } : {}}>
                     <div className={styles.chatContainer}>
                         {!lastQuestionRef.current && dataConversation.length <= 0 ? (
-                            <div className={dataConversation.length > 0 ? styles.chatMessageStream : styles.chatEmptyState} style={conversationIsLoading ? {flexGrow: 1, display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", maxHeight: "1024px", paddingTop: "60px"} : {}}>
-                                {conversationIsLoading && <Spinner size={3} className={styles.spinnerStyles}/>}
-                                
-                                    <div style={!conversationIsLoading ? {
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        alignItems: 'center',
-                                        justifyContent: 'center'} : {display: "none"}}>
-                                            <img height="40px" src={salesLogo}></img>
-                                            <h1>Clew</h1>
-                                            <p style={{ width: "80%", textAlign: "center" }}>Your AI-driven Home Improvement expert who boosts marketing performance by synthesizing multiple data sources to deliver actionable insights.</p>
-                                    </div>
-                                
+                            <div className={dataConversation.length > 0 && !conversationIsLoading ? styles.chatMessageStream : styles.chatEmptyState}>
+                                {conversationIsLoading && <Spinner size={3} className={styles.spinnerStyles} />}
+
+                                <div className={conversationIsLoading ? styles.noneDisplay : styles.flexDescription}>
+                                    <img height="40px" src={salesLogo}></img>
+                                    <h1>Clew</h1>
+                                    <p style={{ width: "80%", textAlign: "center" }}>
+                                        Your AI-driven Home Improvement expert who boosts marketing performance by synthesizing multiple data sources to deliver
+                                        actionable insights.
+                                    </p>
                                 </div>
+                            </div>
                         ) : (
-                            <div  style={conversationIsLoading ? {flexGrow: 1, display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", maxHeight: "1024px", paddingTop: "60px"} : {}} className={!conversationIsLoading ? styles.chatMessageStream : styles.conversationIsLoading}>
-                                {conversationIsLoading && <Spinner size={3} className={styles.spinnerStyles}/>}
-                                {dataConversation.length > 0 ? (
-                                    dataConversation.map((item, index) => {
-                                        const response = {
-                                            answer: item.bot || "",
-                                            conversation_id: chatId,
-                                            data_points: [""],
-                                            thoughts: null
-                                        } as AskResponse
-                                        return(
-                                            <div key={index} style={conversationIsLoading ? {display: "none"} : {}}>
-                                                <UserChatMessage message={item.user} />
-                                                <div className={styles.chatMessageGpt}>
-                                                    <Answer
-                                                        key={index}
-                                                        answer={response}
-                                                        isSelected={selectedAnswer === index && activeAnalysisPanelTab !== undefined}
-                                                        onCitationClicked={(c, n) => onShowCitation(c, n, index)}
-                                                        onThoughtProcessClicked={() => onToggleTab(AnalysisPanelTabs.ThoughtProcessTab, index)}
-                                                        onSupportingContentClicked={() => onToggleTab(AnalysisPanelTabs.SupportingContentTab, index)}
-                                                        onFollowupQuestionClicked={q => makeApiRequestGpt(q, null)}
-                                                        showFollowupQuestions={false}
-                                                        showSources={true}
-                                                    />
-                                                </div>
-                                            </div>
-                                        )
-                                    })
-                                ) : (
-                                    answers.map((answer, index) => (
-                                        <div key={index} style={conversationIsLoading ? {display: "none"} : {}}>
-                                            <UserChatMessage message={answer[0]} />
-                                            <div className={styles.chatMessageGpt}>
-                                                <Answer
-                                                    key={index}
-                                                    answer={answer[1]}
-                                                    isSelected={selectedAnswer === index && activeAnalysisPanelTab !== undefined}
-                                                    onCitationClicked={(c, n) => onShowCitation(c, n, index)}
-                                                    onThoughtProcessClicked={() => onToggleTab(AnalysisPanelTabs.ThoughtProcessTab, index)}
-                                                    onSupportingContentClicked={() => onToggleTab(AnalysisPanelTabs.SupportingContentTab, index)}
-                                                    onFollowupQuestionClicked={q => makeApiRequestGpt(q, null)}
-                                                    showFollowupQuestions={false}
-                                                    showSources={true}
-                                                />
-                                            </div>
-                                        </div>
-                                    ))
-                                )}
+                            <div className={!conversationIsLoading ? styles.chatMessageStream : styles.conversationIsLoading}>
+                                {conversationIsLoading && <Spinner size={3} className={styles.spinnerStyles} />}
+                                {dataConversation.length > 0
+                                    ? dataConversation.map((item, index) => {
+                                          const response = {
+                                              answer: item.bot || "",
+                                              conversation_id: chatId,
+                                              data_points: [""],
+                                              thoughts: null
+                                          } as AskResponse;
+                                          return (
+                                              <div key={index} className={conversationIsLoading ? styles.noneDisplay : ""}>
+                                                  <UserChatMessage message={item.user} />
+                                                  <div className={styles.chatMessageGpt}>
+                                                      <Answer
+                                                          key={index}
+                                                          answer={response}
+                                                          isSelected={selectedAnswer === index && activeAnalysisPanelTab !== undefined}
+                                                          onCitationClicked={(c, n) => onShowCitation(c, n, index)}
+                                                          onThoughtProcessClicked={() => onToggleTab(AnalysisPanelTabs.ThoughtProcessTab, index)}
+                                                          onSupportingContentClicked={() => onToggleTab(AnalysisPanelTabs.SupportingContentTab, index)}
+                                                          onFollowupQuestionClicked={q => makeApiRequestGpt(q, null)}
+                                                          showFollowupQuestions={false}
+                                                          showSources={true}
+                                                      />
+                                                  </div>
+                                              </div>
+                                          );
+                                      })
+                                    : answers.map((answer, index) => (
+                                          <div key={index} className={conversationIsLoading ? styles.noneDisplay : ""}>
+                                              <UserChatMessage message={answer[0]} />
+                                              <div className={styles.chatMessageGpt}>
+                                                  <Answer
+                                                      key={index}
+                                                      answer={answer[1]}
+                                                      isSelected={selectedAnswer === index && activeAnalysisPanelTab !== undefined}
+                                                      onCitationClicked={(c, n) => onShowCitation(c, n, index)}
+                                                      onThoughtProcessClicked={() => onToggleTab(AnalysisPanelTabs.ThoughtProcessTab, index)}
+                                                      onSupportingContentClicked={() => onToggleTab(AnalysisPanelTabs.SupportingContentTab, index)}
+                                                      onFollowupQuestionClicked={q => makeApiRequestGpt(q, null)}
+                                                      showFollowupQuestions={false}
+                                                      showSources={true}
+                                                  />
+                                              </div>
+                                          </div>
+                                      ))}
 
                                 {isLoading && (
                                     <>
@@ -426,17 +354,24 @@ const Chat = () => {
                                     <>
                                         <UserChatMessage message={lastQuestionRef.current} />
                                         <div className={styles.chatMessageGptMinWidth}>
-                                            <AnswerError error={error_message_text + error.toString()} onRetry={() => makeApiRequestGpt(lastQuestionRef.current, null)} />
+                                            <AnswerError
+                                                error={error_message_text + error.toString()}
+                                                onRetry={() => makeApiRequestGpt(lastQuestionRef.current, chatId !== "" ? chatId : null)}
+                                            />
                                         </div>
                                     </>
                                 ) : null}
                                 <div ref={chatMessageStreamEnd} />
                             </div>
-                        
                         )}
 
                         <div className={styles.chatInput}>
-                            <QuestionInput clearOnSend placeholder={placeholderText} disabled={isLoading} onSend={question => makeApiRequestGpt(question, chatId !== '' ? chatId : null)} />
+                            <QuestionInput
+                                clearOnSend
+                                placeholder={placeholderText}
+                                disabled={isLoading}
+                                onSend={question => makeApiRequestGpt(question, chatId !== "" ? chatId : null)}
+                            />
                         </div>
                     </div>
 

--- a/frontend/src/pages/layout/Layout.module.css
+++ b/frontend/src/pages/layout/Layout.module.css
@@ -76,3 +76,7 @@
 .githubLogo {
     height: 20px;
 }
+
+.layoutOptions{
+    display: flex;
+}

--- a/frontend/src/pages/layout/Layout.tsx
+++ b/frontend/src/pages/layout/Layout.tsx
@@ -54,10 +54,10 @@ const Layout = () => {
                         </ul>
     */}
                     </nav>
-                    <div>
+                    <div className={styles.layoutOptions}>
                         {/*  needs an user to be sent ↓ */}
-                        <SettingsModal user={null} />
                         <ChatHistoryButton onClick={handleShowHistoryPanel}/>
+                        <SettingsModal user={null} />
                     </div>
                 </div>
             </header>

--- a/frontend/src/providers/AppProviders.tsx
+++ b/frontend/src/providers/AppProviders.tsx
@@ -1,25 +1,38 @@
 import React, { createContext, useContext, useState, ReactNode, Dispatch, SetStateAction } from "react";
-import { ConversationHistoryItem } from "../api";
+import { ConversationHistoryItem, ConversationChatItem, ChatTurn } from "../api";
 interface AppContextType {
   showHistoryPanel: boolean;
   setShowHistoryPanel: Dispatch<SetStateAction<boolean>>;
+  refreshFetchHistorial: boolean;
+  setRefreshFetchHistorial: Dispatch<SetStateAction<boolean>>;
   dataHistory: ConversationHistoryItem[];
   setDataHistory: Dispatch<SetStateAction<ConversationHistoryItem[]>>;
-  userId: string,
-  setUserId: Dispatch<SetStateAction<string>>
+  userId: string;
+  setUserId: Dispatch<SetStateAction<string>>;
+  chatId: string;
+  setChatId: Dispatch<SetStateAction<string>>;
+  dataConversation: ChatTurn[];
+  setDataConversation: Dispatch<SetStateAction<ChatTurn[]>>;
+  conversationIsLoading: boolean;
+  setConversationIsLoading: Dispatch<SetStateAction<boolean>>
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
 
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [showHistoryPanel, setShowHistoryPanel] = useState<boolean>(false);
+  const [showHistoryPanel, setShowHistoryPanel] = useState<boolean>(true);
+  const [refreshFetchHistorial, setRefreshFetchHistorial] = useState<boolean>(false);
   const [dataHistory, setDataHistory] = useState<ConversationHistoryItem[]>([]);
+  const [dataConversation, setDataConversation] = useState<ChatTurn[]>([]);
   const [userId, setUserId] = useState<string>("00000000-0000-0000-0000-000000000000");
+  const [chatId, setChatId] = useState<string>("");
+  const [conversationIsLoading, setConversationIsLoading] = useState<boolean>(false);
+
   
 
 
   return (
-    <AppContext.Provider value={{ showHistoryPanel, setShowHistoryPanel, dataHistory, setDataHistory, userId, setUserId }}>
+    <AppContext.Provider value={{ showHistoryPanel, setShowHistoryPanel, dataHistory, setDataHistory, userId, setUserId, dataConversation, setDataConversation, chatId, setChatId, conversationIsLoading, setConversationIsLoading, refreshFetchHistorial, setRefreshFetchHistorial }}>
       {children}
     </AppContext.Provider>
   );


### PR DESCRIPTION
this PR has new functionalities in the history panel as: order the history conversations by date (from new to old), once you start a conversation and the bot answer your question, the panel refresh automatically and show the new conversation, and there are new styles on the interface. Also, I created the endpoint to get the conversations by ID and all the functionality in the frontend.