### PR TITLE
SFC-90 Conversation History Sources are not opening in the side panel

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -440,7 +440,7 @@ const Chat = () => {
                     {dataConversation.length > 0 &&
                         fileType !== "" &&
                         activeAnalysisPanelTab &&
-                        dataConversation.map((data, index) => {
+                        dataConversation.map(data => {
                             const response = {
                                 answer: data.bot || "",
                                 conversation_id: chatId,
@@ -449,10 +449,9 @@ const Chat = () => {
                             } as AskResponse;
                             return (
                                 <AnalysisPanel
-                                    key={index}
                                     className={styles.chatAnalysisPanel}
                                     activeCitation={activeCitation}
-                                    onActiveTabChanged={x => onToggleTab(x, index)}
+                                    onActiveTabChanged={x => onToggleTab(x, selectedAnswer)}
                                     citationHeight="810px"
                                     answer={response}
                                     activeTab={activeAnalysisPanelTab}

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -57,7 +57,7 @@ const Chat = () => {
         setChatSelected,
         setChatIsCleaned,
         chatIsCleaned,
-        settingsPanel,
+        settingsPanel
     } = useAppContext();
 
     const lastQuestionRef = useRef<string>("");
@@ -437,7 +437,30 @@ const Chat = () => {
                             />
                         </div>
                     </div>
-
+                    {dataConversation.length > 0 &&
+                        fileType !== "" &&
+                        activeAnalysisPanelTab &&
+                        dataConversation.map((data, index) => {
+                            const response = {
+                                answer: data.bot || "",
+                                conversation_id: chatId,
+                                data_points: [""],
+                                thoughts: null
+                            } as AskResponse;
+                            return (
+                                <AnalysisPanel
+                                    key={index}
+                                    className={styles.chatAnalysisPanel}
+                                    activeCitation={activeCitation}
+                                    onActiveTabChanged={x => onToggleTab(x, index)}
+                                    citationHeight="810px"
+                                    answer={response}
+                                    activeTab={activeAnalysisPanelTab}
+                                    fileType={fileType}
+                                    onHideTab={hideTab}
+                                />
+                            );
+                        })}
                     {answers.length > 0 && fileType !== "" && activeAnalysisPanelTab && (
                         <AnalysisPanel
                             className={styles.chatAnalysisPanel}


### PR DESCRIPTION
This is a solution for the bug of the panel preview. It had a bug where the panel open many times depends on how many sources there were, so, for example, if there were 3 different sources, it opened 3 times. Now this solution could works.