### PR TITLE
improve error handling and fix document upload/download

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2348,19 +2348,10 @@ def generate_summary():
             }), 500
         
         # Download documents
-        try:
-            downloaded_files = blob_manager.download_documents(equity_name=equity_name)
-            if not downloaded_files: 
-                return jsonify({
-                    'error': 'No documents found',
-                    'details': f'No documents found for equity: {equity_name}'
-                }), 404
-        except Exception as e: # some error codes for blob isn't supported in the current version
-            logging.error(f"Failed to download documents: {str(e)}")
-            return jsonify({
-                'error': 'Download error',
-                'details': 'Failed to download documents from storage service'
-            }), 503
+
+        downloaded_files = blob_manager.download_documents(equity_name=equity_name, 
+                                                               financial_type=financial_type)
+
         # Process documents
         for file_path in downloaded_files:
             doc_id = extract_pdf_pages_to_images(file_path, IMAGE_PATH)

--- a/backend/financial_doc_processor.py
+++ b/backend/financial_doc_processor.py
@@ -318,7 +318,7 @@ class BlobStorageManager:
             raise BlobConnectionError(f"Failed to initialize blob storage: {str(e)}")
 
     def download_documents(self, equity_name: str,
-                         financial_type: str = '10-K',
+                         financial_type: str,
                          exclude_summary: bool = True,
                          local_data_path: str = PDF_PATH) -> List[str]:
         """


### PR DESCRIPTION
This change requires users to provide financial type when downloading documents (previous default to 10-K). Also, remove error handling in app.py since it's already been handled in download_documents
