### PR TITLE
Allow-empty-fields-in-the-workspace-governance

### DIFF
--- a/backend/shared/cosmo_db.py
+++ b/backend/shared/cosmo_db.py
@@ -472,8 +472,6 @@ def patch_organization_data(org_id, patch_data):
 
     for key in allowed_fields:
         if key in patch_data:
-            if not patch_data[key]:
-                raise ValueError(f"Field '{key}' cannot be empty")
             org[key] = patch_data[key]
 
     container.upsert_item(org)

--- a/frontend/src/pages/organization/Organization.tsx
+++ b/frontend/src/pages/organization/Organization.tsx
@@ -33,9 +33,9 @@ const Organization = () => {
         setIsLoading(true);
     
         const patchData: any = {};
-        if (brandInformation) patchData.brandInformation = brandInformation;
-        if (industryInformation) patchData.industryInformation = industryInformation;
-        if (segmentSynonyms) patchData.segmentSynonyms = segmentSynonyms;
+        patchData.brandInformation = brandInformation;
+        patchData.industryInformation = industryInformation;
+        patchData.segmentSynonyms = segmentSynonyms;
         
         try {
             await updateOrganizationInfo({ orgId: organization.id, patchData });


### PR DESCRIPTION
**Fix: Allow empty strings for organization info fields**

This PR addresses an issue where clearing the Brand Description, Business Description, or Segment Synonyms fields on the Organization page and saving did not persist the changes.

The root cause was twofold:
1.  The frontend initially prevented sending empty fields in the PATCH request.
2.  The backend API (`/api/organization/<org_id>`) explicitly validated against and rejected empty strings for these fields (`brandInformation`, `industryInformation`, `segmentSynonyms`).

This PR modifies the backend `patch_organization_data` function in `cosmo_db.py` to remove the validation check, allowing empty strings to be successfully saved for these organization fields. This aligns with the user expectation that clearing a field should save it as empty.
