### PR TITLE
Fa 810 allow only admins to upload files

### DIFF
--- a/frontend/src/pages/resources/UploadResourcescopy.module.css
+++ b/frontend/src/pages/resources/UploadResourcescopy.module.css
@@ -276,6 +276,10 @@
     color: #ff6900;
 }
 
+.icon_excel{
+    color: #71b33b;
+}
+
 .icon_doc{
     color:#0078d4;
 }

--- a/frontend/src/pages/resources/UploadResourcescopy.tsx
+++ b/frontend/src/pages/resources/UploadResourcescopy.tsx
@@ -23,7 +23,9 @@ import { DocumentRegular } from "@fluentui/react-icons";
 import { FileText, Download, Trash2, RefreshCw, Upload, Search, CirclePlus } from "lucide-react";
 import { uploadSourceFileToBlob, getSourceFileFromBlob, deleteSourceFileFromBlob } from "../../api/api";
 import { useAppContext } from "../../providers/AppProviders";
+import { toast, ToastContainer } from "react-toastify";
 const ALLOWED_FILE_TYPES = [".pdf", ".csv", ".xlsx", ".xls"];
+const EXCEL_FILES = ["csv", "xls", "xlsx"]
 
 // Interface for blob data
 interface BlobItem {
@@ -75,6 +77,8 @@ const UploadResources: React.FC = () => {
                 let iconColorClass = "";
                 if (fileExtension === "pdf") {
                     iconColorClass = styles.icon_pdf;
+                } else if (EXCEL_FILES.includes(fileExtension || "")) {
+                    iconColorClass = styles.icon_excel;
                 } else if (["doc", "docx", "odt", "rtf"].includes(fileExtension || "")) {
                     iconColorClass = styles.icon_doc;
                 }
@@ -372,10 +376,17 @@ const UploadResources: React.FC = () => {
 
     // Open upload dialog
     const openUploadDialog = () => {
-        setIsUploadDialogOpen(true);
-        setSelectedFiles([]);
-        setUploadStatus(null);
-        setUploadProgress(0);
+        if (user?.role == "user") {
+            toast("Only Admins can Upload Files", {
+                type: "warning"
+            })
+        }
+        else {
+            setIsUploadDialogOpen(true);
+            setSelectedFiles([]);
+            setUploadStatus(null);
+            setUploadProgress(0);
+        }
     };
 
     // Close upload dialog
@@ -394,6 +405,7 @@ const UploadResources: React.FC = () => {
 
     return (
         <div className={styles.page_container}>
+            <ToastContainer />
             <div className={styles.file_list_header}>
                 <SearchBox
                     placeholder="Search files..."

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -53,6 +53,8 @@ export default defineConfig({
             "/api/logs":"http://localhost:8000/",
             "/api/companydata": "http://localhost:8000/",
             "/api/voice-customer": "http://localhost:8000/",
+            "/api/get-source-documents": "http://127.0.0.1:8000",
+            "api/upload-source-document": "http://127.0.0.1:8000"
         },
         host: true
     }


### PR DESCRIPTION
## JIRA Ticket
[FA-810](lhttps://salesfactoryai.atlassian.net/jira/software/projects/FA/boards/1?selectedIssue=FA-810)

## Description
This PR Allow only Admins and Platforms Managers to Upload Files into blob storage also add new styles for excel icons and vite.config for the upload endpoints

## Checklist
- [*] Code review requested
- [ ] Tests completed
- [ ] Documentation updated
