### PR TITLE
FA 913 Remove Financial Assistant mode toggle (#592)

### DIFF
--- a/frontend/cypress/e2e/chat.cy.ts
+++ b/frontend/cypress/e2e/chat.cy.ts
@@ -42,8 +42,19 @@ describe("Main Page (Chat) Test Suite", () => {
     });
 
     it("Should verify the visibility and functionality of the Settings page", () => {
-        cy.get(":nth-child(3) > ._tooltipWrapper_16w4s_240 > .btn").should("be.visible");
-        cy.get(":nth-child(3) > ._tooltipWrapper_16w4s_240 > .btn").click();
+        cy.get('[data-testid="settings-button"]').should("be.visible");
+        cy.get('[data-testid="settings-button"]').click();
+
+        cy.contains("Chat Settings").should("be.visible");
+        cy.contains("Font Type").should("be.visible");
+        cy.contains("Font Size").should("be.visible");
+        cy.contains("Model Selection").should("be.visible");
+        cy.contains("Creativity Scale").should("be.visible");
+    });
+
+    it("Should verify the visibility and functionality of the Settings page", () => {
+        cy.get('[data-testid="settings-button"]').should("be.visible");
+        cy.get('[data-testid="settings-button"]').click();
 
         cy.contains("Chat Settings").should("be.visible");
         cy.contains("Font Type").should("be.visible");
@@ -53,18 +64,11 @@ describe("Main Page (Chat) Test Suite", () => {
     });
 
     it("Should verify the functionality of the Save Settings button", () => {
-        cy.get(":nth-child(3) > ._tooltipWrapper_16w4s_240 > .btn").should("be.visible");
-        cy.get(":nth-child(3) > ._tooltipWrapper_16w4s_240 > .btn").click();
+        cy.get('[data-testid="settings-button"]').should("be.visible");
+        cy.get('[data-testid="settings-button"]').click();
 
         // Verify the Save Settings button is visible
-        cy.get('[aria-label="Save settings"]').should("be.visible");
-
-        // Click the Save Settings button
-        cy.get('[aria-label="Save settings"]').click();
-
-        cy.get(".ms-Button--primary").should("be.visible");
-        cy.get(".ms-Button--primary").contains("Save").should("be.visible");
-        cy.get(".ms-Button--primary").click();
+        cy.get('[aria-label="Save settings"]').should("be.visible").and("be.enabled");
     });
 
     it("should verify the visibility and functionality of the Chat History", () => {

--- a/frontend/cypress/e2e/subscription_management.cy.ts
+++ b/frontend/cypress/e2e/subscription_management.cy.ts
@@ -190,12 +190,12 @@ describe("Subscription Page tests", () => {
         cy.get('span').should('contain.text', 'Subscription Management');
         cy.get('div').should('contain.text', 'Premium');
         
-        // Verify financial assistant section with an active subscription
-        cy.get('h3').should('contain.text', 'Financial Assistant');
-        cy.get('input.form-check-input').click();
-        cy.get('span').should('contain.text', 'Unsubscribe from Financial Assistant');
-        cy.get('button').contains('Yes, Unsubscribe').should('be.visible');
-        cy.get('button').contains('Cancel').should('be.visible').click();
+        // // Verify financial assistant section with an active subscription
+        // cy.get('h3').should('contain.text', 'Financial Assistant');
+        // cy.get('input.form-check-input').click();
+        // cy.get('span').should('contain.text', 'Unsubscribe from Financial Assistant');
+        // cy.get('button').contains('Yes, Unsubscribe').should('be.visible');
+        // cy.get('button').contains('Cancel').should('be.visible').click();
 
         // Checks the View Plan information
         cy.get('button').contains('View').should('be.visible').click();

--- a/frontend/src/components/Navbar/NavBarcopy.tsx
+++ b/frontend/src/components/Navbar/NavBarcopy.tsx
@@ -323,7 +323,7 @@ const Navbar: React.FC<NavbarProps> = ({ isCollapsed, setIsCollapsed }) => {
                     <ul className="navbar-nav flex-row align-items-center gap-3">
                         {/*Then change the route*/}
                         {/* Financial Assistant Toggle */}
-                        {fastatus && location === "/" && (
+                        {/* {fastatus && location === "/" && (
                             <li className="nav-item">
                                 <div className="d-flex flex-column align-items-start">
                                     <div className={styles.financialToggleContainer}>
@@ -339,7 +339,7 @@ const Navbar: React.FC<NavbarProps> = ({ isCollapsed, setIsCollapsed }) => {
                                     </div>
                                 </div>
                             </li>
-                        )}
+                        )} */}
                         {/*Then change the route*/}
                         {/* Feedback Panel Button */}
                         {/* {location === "/" && (
@@ -389,7 +389,11 @@ const Navbar: React.FC<NavbarProps> = ({ isCollapsed, setIsCollapsed }) => {
                         {location === "/" && (
                             <li className="nav-item">
                                 <div className={styles.tooltipWrapper}>
-                                    <button onClick={handleShowSettings} className="btn btn-white btn-sm d-flex align-items-center gap-1">
+                                    <button
+                                        onClick={handleShowSettings}
+                                        className="btn btn-white btn-sm d-flex align-items-center gap-1"
+                                        data-testid="settings-button"
+                                    >
                                         <Settings className={styles.iconLarge} />
                                         <span className={styles.tooltipText}>Chat Settings</span>
                                         {/* <span className="d-none d-md-inline">Settings</span> */}

--- a/frontend/src/pages/chat/Chatcopy.tsx
+++ b/frontend/src/pages/chat/Chatcopy.tsx
@@ -16,7 +16,7 @@ import { useAppContext } from "../../providers/AppProviders";
 //import { FeedbackRating } from "../../components/FeedbackRating/FeedbackRating";
 import StartNewChatButton from "../../components/StartNewChatButton/StartNewChatButtoncopy";
 import DownloadButton from "../../components/DownloadButton/DownloadButton";
-import FinancialPopup from "../../components/FinancialAssistantPopup/FinancialAssistantPopup";
+// import FinancialPopup from "../../components/FinancialAssistantPopup/FinancialAssistantPopup";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import FreddaidLogo from "../../img/FreddaidLogo.png";
@@ -100,7 +100,8 @@ const Chat = () => {
         setLastAnswer("");
         setProgressState(null);
 
-        const agent = isFinancialAssistantActive ? "financial" : "consumer";
+        const agent = "consumer";
+        // const agent = isFinancialAssistantActive ? "financial" : "consumer";
 
         let history: ChatTurn[] = [];
         if (dataConversation.length > 0) {
@@ -485,7 +486,7 @@ const Chat = () => {
                 <div>
                     {/* <div className={showFeedbackRatingPanel ? styles.commandsContainer : styles.hidden}>{showFeedbackRatingPanel && <FeedbackRating />}</div> */}
                 </div>
-                <FinancialPopup />
+                {/* <FinancialPopup /> */}
                 <div className={styles.container}>
                     <div className={styles.chatRoot}>
                         <div style={{ display: "flex", flexDirection: "row", width: "100%", height: "100%" }}>
@@ -505,7 +506,7 @@ const Chat = () => {
                                                 </p>
                                             </div>
                                         )}
-                                        {isFinancialAssistantActive && (
+                                        {/* {isFinancialAssistantActive && (
                                             <div className={conversationIsLoading ? styles.noneDisplay : styles.flexDescription}>
                                                 <img height="70px" src={FreddaidLogoFinlAi} alt="FreddAid 4.1"></img>
                                                 <h1>FinlAI</h1>
@@ -515,7 +516,7 @@ const Chat = () => {
                                                     opportunities and threats in an ever-changing financial landscape.
                                                 </p>
                                             </div>
-                                        )}
+                                        )} */}
                                     </div>
                                 ) : (
                                     <div

--- a/frontend/src/pages/subscriptionmanagement/SubscriptionManagementcopy.tsx
+++ b/frontend/src/pages/subscriptionmanagement/SubscriptionManagementcopy.tsx
@@ -376,12 +376,12 @@ const SubscriptionManagement: React.FC = () => {
                                     </div>
                                 </td>
                             </tr>
-                            <tr key="divider">
+                            {/* <tr key="divider">
                                 <td colSpan={3} className={styles.divider}>
                                     <div className={styles.dividerText}>Additional Services</div>
                                     <div className={styles.addonWrapper}>
                                         <div className={styles.addonCard}>
-                                            {/* Financial Assistant */}
+                                            
                                             <div className={styles.addonItem}>
                                                 <div className={styles.addonInfo}>
                                                     <div className={styles.iconWrapper}>
@@ -410,144 +410,141 @@ const SubscriptionManagement: React.FC = () => {
                                         </div>
                                     </div>
                                 </td>
-                            </tr>
+                            </tr> */}
                         </tbody>
                     </table>
                 )}
                 {isRecentChangesModal && (
                     <div className={styles.modalOverlay}>
-
-                    <div ref={recentChangesModalRef} className={styles.modalAudit}>
-                        <div className={styles.modalHeader}>
-                            <h1 className={styles.titleRecent}>Recent Changes</h1>
-                            <button aria-label="Close" className={styles.closeButton} onClick={() => setIsRecentChangesModal(false)}>
-                                <IconX />
-                            </button>
-                        </div>
-                        <div className={styles.auditFilter}>
-                            <Label className={styles.modalText}>Filter by Action:</Label>
-                            <Dropdown
-                                placeholder="Select action to filter"
-                                options={FilterOptions}
-                                onChange={handleFilterChange}
-                                styles={{
-                                    title: { fontSize: "1rem" },
-                                    dropdownItem: { fontSize: "1rem" },
-                                    dropdownItemSelected: { fontSize: "1rem" },
-                                    root: { fontSize: "1rem" }
-                                }}
-                            />
-                        </div>
-                        {recentChangesLoading ? (
-                            <Spinner styles={{ root: { marginTop: "50px" } }} />
-                        ) : (
-                            <div className={styles.row} style={{ overflowX: "auto", width: "100%" }}>
-                                <div style={{ width: "100%", minWidth: 320 }}>
-                                    <table className={styles.table} style={{ width: "100%", minWidth: 320 }}>
-                                        <thead className={styles.thead}>
-                                            <tr key="types">
-                                                <th className={styles.tableName}>Date</th>
-                                                <th className={styles.tableName}>Action</th>
-                                                <th className={styles.tableName}>Modified by</th>
-                                                <th className={styles.tableName}>Details</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody className={styles.auditBody}>
-                                            {(logsToShow || []).map((data: any, index: number) => (
-                                                <tr className={styles.auditRow} key={index}>
-                                                    {data.action === "Subscription Tier Change" && (
-                                                        <>
-                                                            <td className={styles.tableDate}>{formatTimestamp(data._ts)}</td>
-                                                            <td className={styles.tableText2}>Subscription Tier Change</td>
-                                                            <td className={styles.tableText2}>{data.modified_by_name}</td>
-                                                            <td className={styles.tableText2}>
-                                                                {data.previous_plan} → {data.current_plan}
-                                                            </td>
-                                                        </>
-                                                    )}
-                                                    {data.action === "Financial Assistant Change" && (
-                                                        <>
-                                                            <td className={styles.tableDate}>{formatTimestamp(data._ts)}</td>
-                                                            <td className={styles.tableText2}>FA Add-On Toggled</td>
-                                                            <td className={styles.tableText2}>{data.modified_by_name}</td>
-                                                            <td className={styles.tableStatus}>Status: {data.status_financial_assistant}</td>
-                                                        </>
-                                                    )}
-                                                    {data.action === "Subscription Created" && (
-                                                        <>
-                                                            <td className={styles.tableDate}>{formatTimestamp(data._ts)}</td>
-                                                            <td className={styles.tableText2}>Subscription Created</td>
-                                                            <td className={styles.tableText}>{data.modified_by_name}</td>
-                                                            <td className={styles.tableText}>Status: Active</td>
-                                                        </>
-                                                    )}
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
-                                    {(filteredLogsData?.length === 0 || !filteredLogsData) && (
-                                        <p style={{ textAlign: "center", marginTop: 16 }}>No logs found</p>
-                                    )}
-                                    {/* Mobile Pagination Controls */}
-                                    {isMobile && filteredLogsData && filteredLogsData.length > 5 && (
-                                        <div style={{ display: "flex", justifyContent: "center", marginTop: 12, gap: 8 }}>
-                                            <button
-                                                className={styles.button}
-                                                onClick={() => setMobilePage(p => Math.max(1, p - 1))}
-                                                disabled={mobilePage === 1}
-                                            >
-                                                Prev
-                                            </button>
-                                            <span style={{ alignSelf: "center" }}>
-                                                {mobilePage} / {totalMobilePages}
-                                            </span>
-                                            <button
-                                                className={styles.button}
-                                                onClick={() => setMobilePage(p => Math.min(totalMobilePages, p + 1))}
-                                                disabled={mobilePage === totalMobilePages}
-                                            >
-                                                Next
-                                            </button>
-                                        </div>
-                                    )}
-                                </div>
-                            </div>
-                            
-                        )}
-                    </div>
-                    </div>
-
-                )}
-                {isViewModal && (
-                    <div className={styles.modalOverlay} >
-                    <div className={styles.modalSubscription} ref={viewModalRef}>
-                        <button aria-label="Close" className={styles.closeButton} onClick={() => setIsViewModal(false)}>
-                            <IconX />
-                        </button>
-                        {prices.map((price, index) => (
-                            <div key={price.id} className={`${price.nickname === subscriptionName ? styles.activePlan : styles.plan}`}>
-                                <ChartPerson48Regular className={styles.planIcon} />
-                                <h2 className={styles.planName}>{price.nickname}</h2>
-                                <p className={styles.planDescription}>{price.description}</p>
-
-                                <p className={styles.planPrice}>
-                                    ${(price.unit_amount / 100).toFixed(2)} {price.currency.toUpperCase()} per {price.recurring?.interval}
-                                </p>
-                                <button
-                                    className={styles.planButton}
-                                    onClick={() => handleSelectedSubscription(price.nickname, price.id)}
-                                    role="button"
-                                    aria-label={`Subscribe to ${price.nickname}`}
-                                >
-                                    {organization?.subscriptionId && organization.subscriptionStatus === "inactive"
-                                        ? "Reactivate subscription"
-                                        : organization?.subscriptionStatus === "active" && price.nickname === subscriptionName
-                                        ? "Change payment information"
-                                        : "Subscribe"}
+                        <div ref={recentChangesModalRef} className={styles.modalAudit}>
+                            <div className={styles.modalHeader}>
+                                <h1 className={styles.titleRecent}>Recent Changes</h1>
+                                <button aria-label="Close" className={styles.closeButton} onClick={() => setIsRecentChangesModal(false)}>
+                                    <IconX />
                                 </button>
                             </div>
-                        ))}
+                            <div className={styles.auditFilter}>
+                                <Label className={styles.modalText}>Filter by Action:</Label>
+                                <Dropdown
+                                    placeholder="Select action to filter"
+                                    options={FilterOptions}
+                                    onChange={handleFilterChange}
+                                    styles={{
+                                        title: { fontSize: "1rem" },
+                                        dropdownItem: { fontSize: "1rem" },
+                                        dropdownItemSelected: { fontSize: "1rem" },
+                                        root: { fontSize: "1rem" }
+                                    }}
+                                />
+                            </div>
+                            {recentChangesLoading ? (
+                                <Spinner styles={{ root: { marginTop: "50px" } }} />
+                            ) : (
+                                <div className={styles.row} style={{ overflowX: "auto", width: "100%" }}>
+                                    <div style={{ width: "100%", minWidth: 320 }}>
+                                        <table className={styles.table} style={{ width: "100%", minWidth: 320 }}>
+                                            <thead className={styles.thead}>
+                                                <tr key="types">
+                                                    <th className={styles.tableName}>Date</th>
+                                                    <th className={styles.tableName}>Action</th>
+                                                    <th className={styles.tableName}>Modified by</th>
+                                                    <th className={styles.tableName}>Details</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody className={styles.auditBody}>
+                                                {(logsToShow || []).map((data: any, index: number) => (
+                                                    <tr className={styles.auditRow} key={index}>
+                                                        {data.action === "Subscription Tier Change" && (
+                                                            <>
+                                                                <td className={styles.tableDate}>{formatTimestamp(data._ts)}</td>
+                                                                <td className={styles.tableText2}>Subscription Tier Change</td>
+                                                                <td className={styles.tableText2}>{data.modified_by_name}</td>
+                                                                <td className={styles.tableText2}>
+                                                                    {data.previous_plan} → {data.current_plan}
+                                                                </td>
+                                                            </>
+                                                        )}
+                                                        {data.action === "Financial Assistant Change" && (
+                                                            <>
+                                                                <td className={styles.tableDate}>{formatTimestamp(data._ts)}</td>
+                                                                <td className={styles.tableText2}>FA Add-On Toggled</td>
+                                                                <td className={styles.tableText2}>{data.modified_by_name}</td>
+                                                                <td className={styles.tableStatus}>Status: {data.status_financial_assistant}</td>
+                                                            </>
+                                                        )}
+                                                        {data.action === "Subscription Created" && (
+                                                            <>
+                                                                <td className={styles.tableDate}>{formatTimestamp(data._ts)}</td>
+                                                                <td className={styles.tableText2}>Subscription Created</td>
+                                                                <td className={styles.tableText}>{data.modified_by_name}</td>
+                                                                <td className={styles.tableText}>Status: Active</td>
+                                                            </>
+                                                        )}
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                        {(filteredLogsData?.length === 0 || !filteredLogsData) && (
+                                            <p style={{ textAlign: "center", marginTop: 16 }}>No logs found</p>
+                                        )}
+                                        {/* Mobile Pagination Controls */}
+                                        {isMobile && filteredLogsData && filteredLogsData.length > 5 && (
+                                            <div style={{ display: "flex", justifyContent: "center", marginTop: 12, gap: 8 }}>
+                                                <button
+                                                    className={styles.button}
+                                                    onClick={() => setMobilePage(p => Math.max(1, p - 1))}
+                                                    disabled={mobilePage === 1}
+                                                >
+                                                    Prev
+                                                </button>
+                                                <span style={{ alignSelf: "center" }}>
+                                                    {mobilePage} / {totalMobilePages}
+                                                </span>
+                                                <button
+                                                    className={styles.button}
+                                                    onClick={() => setMobilePage(p => Math.min(totalMobilePages, p + 1))}
+                                                    disabled={mobilePage === totalMobilePages}
+                                                >
+                                                    Next
+                                                </button>
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+                        </div>
                     </div>
+                )}
+                {isViewModal && (
+                    <div className={styles.modalOverlay}>
+                        <div className={styles.modalSubscription} ref={viewModalRef}>
+                            <button aria-label="Close" className={styles.closeButton} onClick={() => setIsViewModal(false)}>
+                                <IconX />
+                            </button>
+                            {prices.map((price, index) => (
+                                <div key={price.id} className={`${price.nickname === subscriptionName ? styles.activePlan : styles.plan}`}>
+                                    <ChartPerson48Regular className={styles.planIcon} />
+                                    <h2 className={styles.planName}>{price.nickname}</h2>
+                                    <p className={styles.planDescription}>{price.description}</p>
+
+                                    <p className={styles.planPrice}>
+                                        ${(price.unit_amount / 100).toFixed(2)} {price.currency.toUpperCase()} per {price.recurring?.interval}
+                                    </p>
+                                    <button
+                                        className={styles.planButton}
+                                        onClick={() => handleSelectedSubscription(price.nickname, price.id)}
+                                        role="button"
+                                        aria-label={`Subscribe to ${price.nickname}`}
+                                    >
+                                        {organization?.subscriptionId && organization.subscriptionStatus === "inactive"
+                                            ? "Reactivate subscription"
+                                            : organization?.subscriptionStatus === "active" && price.nickname === subscriptionName
+                                            ? "Change payment information"
+                                            : "Subscribe"}
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
                     </div>
                 )}
                 {isConfirmationModal && (


### PR DESCRIPTION
Release: FA-913 - Remove Financial Assistant Mode Toggle

  Description:
  ## Summary
  This release removes the Financial Assistant mode toggle functionality from the application.

  • **FA-913**: Remove Financial Assistant mode toggle ✅

  ## Changes Included

  ### FA-913: Remove Financial Assistant Mode Toggle
  - Removed Financial Assistant toggle from navigation bar
  - Commented out Financial Assistant UI components and popups
  - Updated chat logic to use consumer agent only
  - Removed Financial Assistant sections from subscription management
  - Updated Cypress tests to reflect UI changes
  - Added proper test IDs for better test reliability

  ## Files Modified
  - `frontend/src/components/Navbar/NavBarcopy.tsx` - Removed FA toggle from navbar
  - `frontend/src/pages/chat/Chatcopy.tsx` - Removed FA mode logic and UI elements
  - `frontend/src/pages/subscriptionmanagement/SubscriptionManagementcopy.tsx` - Commented out FA
  sections
  - `frontend/cypress/e2e/chat.cy.ts` - Updated test selectors and removed FA-related tests
  - `frontend/cypress/e2e/subscription_management.cy.ts` - Commented out FA subscription tests

  ## Test Plan
  - [x] Verify Financial Assistant toggle is no longer visible in navigation
  - [x] Confirm chat interface defaults to consumer agent only
  - [x] Test subscription management page without FA sections
  - [x] Verify Cypress tests pass with updated selectors
  - [ ] Manual testing of all affected UI components