### PR TITLE
FA - 937 Set default sort in Viz Vault to Latest

### DIFF
--- a/frontend/src/pages/gallery/Gallery.tsx
+++ b/frontend/src/pages/gallery/Gallery.tsx
@@ -7,7 +7,7 @@ import { deleteSourceFileFromBlob, getFileBlob, getGalleryItems, getUsers } from
 import { useAppContext } from "../../providers/AppProviders";
 
 const statusFilterOptions = [
-    { label: "Newest", value: "newest" },
+    { label: "Latest", value: "latest" },
     { label: "Oldest", value: "oldest" }
 ];
 
@@ -41,7 +41,7 @@ const Gallery: React.FC = () => {
     const { user, organization } = useAppContext();
 
     const [showStatusFilter, setShowStatusFilter] = useState<boolean>(false);
-    const [selectedStatus, setSelectedStatus] = useState<string>();
+    const [selectedStatus, setSelectedStatus] = useState<string>("latest");
     const [userFilter, setUserFilter] = useState<string | null>(null);
     const [images, setImages] = useState<GalleryItem[]>([]);
     const [fetchedImages, setFetchedImages] = useState<GalleryItem[]>([]);
@@ -83,6 +83,12 @@ const Gallery: React.FC = () => {
                     setIsLoading(false);
                     return;
                 }
+
+                galleryData = [...galleryData].sort((a, b) => {
+                    const ta = Date.parse(a.created_on || a.last_modified || "") || 0;
+                    const tb = Date.parse(b.created_on || b.last_modified || "") || 0;
+                    return tb - ta;
+                });
 
                 setImages(galleryData);
                 setFetchedImages(galleryData);
@@ -148,7 +154,7 @@ const Gallery: React.FC = () => {
         base.sort((a, b) => {
             const ta = Date.parse(a.created_on || a.last_modified || "") || 0;
             const tb = Date.parse(b.created_on || b.last_modified || "") || 0;
-            return order === "newest" ? tb - ta : ta - tb;
+            return order === "latest" ? tb - ta : ta - tb;
         });
         setImages(base);
     };


### PR DESCRIPTION
## JIRA Ticket
[FA-937](https://salesfactoryai.atlassian.net/browse/FA-937)

## Description
- Set default sort order to 'Latest' when opening Viz Vault
- Items appear in descending chronological order (newest first)
- Users can still manually switch to 'Oldest'
- The default sort applies consistently across all Viz Vault entry points

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated
