### PR TITLE
FA-947 Source link not generated correctly when Excel filename ends with a number in parentheses

### DIFF
--- a/frontend/src/components/Answer/AnswerParser.tsx
+++ b/frontend/src/components/Answer/AnswerParser.tsx
@@ -20,7 +20,7 @@ import { useAppContext } from "../../providers/AppProviders";
  * ---------------------------------------------------------------- */
 const RX_MARKDOWN_LINK = /(?<!!)\[([^\]]+)\]\(([^)]+)\)/g; // skip image markdown
 const RX_WRONG_NUMBERS = /\[\^(\d+)\^\]/g; // ↳ [^1^] ➜ [1]
-const RX_CITATION_BLOCK = /\[\[([^\]]+)\]\]\(([^)]+)\)/g; // [[1]](url)
+const RX_CITATION_BLOCK = /\[\[([^\]]+)\]\]\(((?:[^\(\)]|\([^\(\)]*\))+)\)/g; // [[1]](url) allows simple balanced parentheses
 
 /* ------------------------------------------------------------------
  * Types

--- a/frontend/src/components/Answer/parseAnswerToHtml.test.ts
+++ b/frontend/src/components/Answer/parseAnswerToHtml.test.ts
@@ -99,7 +99,7 @@ describe("parseAnswerToHtml()", () => {
 
     it('handles citations with parentheses in filename', () => {
       mockIsResizing = false;
-      const md = 'Archivo [[1]](megustalaarepa(1).xlsx) and [[2]](file(2).pdf)';
+      const md = 'File [[1]](megustalaarepa(1).xlsx) and [[2]](file(2).pdf)';
       const { answerHtml, citations } = parseAnswerToHtml(md, true, noopClick);
 
       expect(citations).toEqual(['megustalaarepa(1).xlsx', 'file(2).pdf']);

--- a/frontend/src/components/Answer/parseAnswerToHtml.test.ts
+++ b/frontend/src/components/Answer/parseAnswerToHtml.test.ts
@@ -96,6 +96,18 @@ describe("parseAnswerToHtml()", () => {
         expect(citations).toEqual(["Same.pdf"]); // deduped
         expect(answerHtml.match(/<sup>1<\/sup>/g)).toHaveLength(2);
     });
+
+    it('handles citations with parentheses in filename', () => {
+      mockIsResizing = false;
+      const md = 'Archivo [[1]](megustalaarepa(1).xlsx) and [[2]](file(2).pdf)';
+      const { answerHtml, citations } = parseAnswerToHtml(md, true, noopClick);
+
+      expect(citations).toEqual(['megustalaarepa(1).xlsx', 'file(2).pdf']);
+      expect(answerHtml).toMatch(/<sup>1<\/sup>/);
+      expect(answerHtml).toMatch(/<sup>2<\/sup>/);
+      expect(answerHtml).not.toContain('[[1]]');
+      expect(answerHtml).not.toContain('[[2]]');
+    });
 });
 
 describe("removeCitationsBlock()", () => {


### PR DESCRIPTION
## JIRA Ticket
[FA-947](https://salesfactoryai.atlassian.net/browse/FA-947)

## Description
[* Fix issues citations with parentheses]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated
