### PR TITLE
FA-970 feat: Integrate Flask-Limiter for rate limiting in the applica…

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -27,6 +27,8 @@ import tempfile
 import markdown
 from flask_cors import CORS
 from flask_compress import Compress
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from azure.identity import DefaultAzureCredential
 from urllib.parse import unquote, urlparse, urlencode, urljoin
 import uuid
@@ -180,6 +182,15 @@ CORS(app)
 
 # Enable compression for all responses
 Compress(app)
+
+# Initialize Flask-Limiter with basic configuration
+limiter = Limiter(
+    app=app,
+    key_func=get_remote_address,
+    default_limits=["1000 per hour", "100 per minute"],
+    storage_uri="memory://",
+    strategy="fixed-window"
+)
 
 
 def setup_llm() -> PandasAIClient:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ azure-identity==1.15.0
 flask==2.2.2
 flask-cors==3.0.10
 flask-compress==1.18
+flask-limiter==3.13
 werkzeug==2.2.2
 requests
 python-dotenv==1.0.0


### PR DESCRIPTION
…tion

* Added Flask-Limiter to manage request limits with a default of 1000 per hour and 100 per minute.
* Configured the limiter to use the client's IP address for tracking requests.

## JIRA Ticket
[FA-970](https://salesfactoryai.atlassian.net/jira/software/projects/FA/boards/1?selectedIssue=FA-970)

## Description
[Describe your changes here]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated
