### PR TITLE
FA-1036-Invalid_Detail_Level_Response

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1744,15 +1744,17 @@ def setSettings(*, context):
         detail_level = request_body.get("detail_level")
 
         ALLOWED_DETAIL_LEVELS = {"brief", "balanced", "detailed"}
-        if detail_level is not None and detail_level not in ALLOWED_DETAIL_LEVELS:
-            return (
-                jsonify({
-                    "error": "invalid_detail_level",
-                    "message": f"Invalid detail_level '{detail_level}'. "
-                               f"Allowed: {', '.join(sorted(ALLOWED_DETAIL_LEVELS))}."
-                }),
-                400,
-            )
+
+        if detail_level is not None:
+            detail_level_norm = str(detail_level).strip().lower()
+            if detail_level_norm not in ALLOWED_DETAIL_LEVELS:
+                logging.warning(
+                    "[/api/settings] Invalid detail_level '%s' — falling back to 'balanced'.",
+                    detail_level
+                )
+                detail_level = "balanced"
+            else:
+                detail_level = detail_level_norm
 
         set_settings(
             client_principal=client_principal,


### PR DESCRIPTION
## JIRA Ticket
[PROJ-XXX](link-to-ticket)

Attending Manuel comment:

[backend/utils.py](https://github.com/Salesfactory/gpt-rag-frontend/pull/686/files/5156f00c635914bc3df2843069af0aa635bb64ee#diff-8c48548c919822f1d855f7fc66b300d2ea1dfc446a9f712c4563a5f0b0041853)
        logging.error(f"[util__module] set_settings: invalid model value {model}.")
        return

    # validate detail level
Collaborator
@[maacaro](https://github.com/maacaro) maacaro [24 minutes ago](https://github.com/Salesfactory/gpt-rag-frontend/pull/686#discussion_r2402217983)
@LuisMRL1997 If the detail_level is not valid, shouldn’t the user receive a proper response (e.g., 401 Invalid detail_level)?

To handle this with an early return, wouldn’t it make sense to perform the validation in the endpoint before calling the setSetting function?

You might also want to take a look at this post on the return early pattern: https://medium.com/swlh/return-early-pattern-3d18a41bba8

## Description
[Describe your changes here]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated
