### PR TITLE
FA-1353 Add “Text Documents” as a Vault File Type (Filter + Icon)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3493,7 +3493,7 @@ def get_gallery(*, context, organization_id):
         file_type = request.args.get("file_type") or request.args.get("type")
         if file_type:
             file_type = file_type.lower()
-            if file_type not in {"images", "pptx"}:
+            if file_type not in {"images", "pptx", "text_documents"}:
                 return create_error_response("Invalid file type filter.", 400)
 
         # Pagination parameters

--- a/backend/gallery/blob_utils.py
+++ b/backend/gallery/blob_utils.py
@@ -15,6 +15,11 @@ PPTX_EXTENSIONS = {".pptx"}
 PPTX_CONTENT_TYPES = {
     "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 }
+TEXT_DOCUMENT_EXTENSIONS = {".docx", ".doc"}
+TEXT_DOCUMENT_CONTENT_TYPES = {
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/msword"
+}
 
 class GalleryRetrievalError(Exception):
     """Custom exception for gallery retrieval errors."""
@@ -129,6 +134,11 @@ def _matches_file_type(blob: Dict[str, Any], desired: Optional[str]) -> bool:
         if content_type in PPTX_CONTENT_TYPES:
             return True
         return any(name.endswith(ext) for ext in PPTX_EXTENSIONS)
+
+    if desired == "text_documents":
+        if content_type in TEXT_DOCUMENT_CONTENT_TYPES:
+            return True
+        return any(name.endswith(ext) for ext in TEXT_DOCUMENT_EXTENSIONS)
 
     return True
 
@@ -282,7 +292,7 @@ def get_gallery_items_by_org(
     4. Paginate the sorted results
     
     - Filter by metadata.user_id == uploader_id (case-insensitive).
-    - Filter by requested file_type (images | pptx).
+    - Filter by requested file_type (images | pptx | text_documents).
     - Search by query across name, content_type, and serialized metadata.
     - Sort by created_on (fallback: last_modified). order: 'newest' | 'oldest'.
     - Apply pagination with page and limit parameters.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1885,7 +1885,7 @@ export async function getGalleryItems(
         uploader_id?: string | null;
         order?: "newest" | "oldest";
         query?: string;
-        file_type?: "images" | "pptx";
+        file_type?: "images" | "pptx" | "text_documents";
         page?: number;
         limit?: number;
         signal?: AbortSignal;

--- a/frontend/src/pages/gallery/Gallery.tsx
+++ b/frontend/src/pages/gallery/Gallery.tsx
@@ -35,8 +35,9 @@ const statusFilterOptions = [
 
 const fileTypeFilterOptions = [
     { label: "All Types", value: "all" },
-    { label: "Images", value: "images" },
-    { label: "PowerPoint", value: "pptx" }
+    { label: "Images/Charts", value: "images" },
+    { label: "Presentations", value: "pptx" },
+    { label: "Text Documents", value: "text_documents" }
 ] as const;
 
 type FileTypeFilter = (typeof fileTypeFilterOptions)[number]["value"];


### PR DESCRIPTION

## JIRA Ticket
[FA-1353](http://salesfactoryai.atlassian.net/browse/FA-1353)

## Description
[Add support for text documents as a file type in gallery filtering]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated
